### PR TITLE
Fixed loop scroll issue by adding Math.trunc in line 820 in Carousel

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -818,7 +818,7 @@ export default class Carousel extends Component {
         }
 
         if (nextActiveItem === this._itemToSnapTo &&
-            scrollOffset === this._scrollOffsetRef) {
+            Math.trunc(scrollOffset) === Math.trunc(this._scrollOffsetRef)) {
             this._repositionScroll(nextActiveItem);
         }
 


### PR DESCRIPTION
The issue was a floating-point comparison between scrollOffset and scrollOffsetRef, truncating the value fixed the issue